### PR TITLE
Remove default 'id' and 'title' traits from the settings panel

### DIFF
--- a/docs/.vuepress/public/grapes.min.js
+++ b/docs/.vuepress/public/grapes.min.js
@@ -2426,7 +2426,7 @@
               attributes: '',
               classes: '',
               script: '',
-              traits: ['id', 'title'],
+              traits: [],
               propagate: '',
               toolbar: null,
             },
@@ -20959,7 +20959,7 @@
           return t && t.__esModule ? t : { default: t };
         })(n(39));
       t.exports = r.default.extend(
-        { defaults: i({}, r.default.prototype.defaults, { tagName: 'label', traits: ['id', 'title', 'for'] }) },
+        { defaults: i({}, r.default.prototype.defaults, { tagName: 'label', traits: [] }) },
         {
           isComponent: function (t) {
             if ('LABEL' == t.tagName) return { type: 'label' };

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -54,7 +54,7 @@ component.get('tagName');
 - `script` **([String][1] | [Function][4])?** Component's javascript. More about it [here][7]. Default: `''`
 - `script-export` **([String][1] | [Function][4])?** You can specify javascript available only in export functions (eg. when you get the HTML).
   If this property is defined it will overwrite the `script` one (in export functions). Default: `''`
-- `traits` **[Array][5]<([Object][2] | [String][1])>?** Component's traits. More about it [here][8]. Default: `['id', 'title']`
+- `traits` **[Array][5]<([Object][2] | [String][1])>?** Component's traits. More about it [here][8]. Default: `[]`
 - `propagate` **[Array][5]<[String][1]>?** Indicates an array of properties which will be inhereted by all NEW appended children.
   For example if you create a component likes this: `{ removable: false, draggable: false, propagate: ['removable', 'draggable'] }`
   and append some new component inside, the new added component will get the exact same properties indicated in the `propagate` array (and the `propagate` property itself). Default: `[]`

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@benbrunyee/grapesjs-docs",
   "private": true,
   "description": "Free and Open Source Web Builder Framework",
-  "version": "0.21.14",
+  "version": "0.21.14.1",
   "license": "BSD-3-Clause",
   "homepage": "http://grapesjs.com",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@benbrunyee/grapesjs",
   "description": "Free and Open Source Web Builder Framework",
-  "version": "0.21.14",
+  "version": "0.21.14.1",
   "author": "Artur Arseniev",
   "license": "BSD-3-Clause",
   "homepage": "http://grapesjs.com",

--- a/packages/core/src/dom_components/model/Component.ts
+++ b/packages/core/src/dom_components/model/Component.ts
@@ -120,7 +120,7 @@ export const keyUpdateInside = ComponentsEvents.updateInside;
  * @property {String|Function} [script=''] Component's javascript. More about it [here](/modules/Components-js.html). Default: `''`
  * @property {String|Function} [script-export=''] You can specify javascript available only in export functions (eg. when you get the HTML).
  * If this property is defined it will overwrite the `script` one (in export functions). Default: `''`
- * @property {Array<Object|String>} [traits=''] Component's traits. More about it [here](/modules/Traits.html). Default: `['id', 'title']`
+ * @property {Array<Object|String>} [traits=''] Component's traits. More about it [here](/modules/Traits.html). Default: `[]`
  * @property {Array<String>} [propagate=[]] Indicates an array of properties which will be inhereted by all NEW appended children.
  *  For example if you create a component likes this: `{ removable: false, draggable: false, propagate: ['removable', 'draggable'] }`
  *  and append some new component inside, the new added component will get the exact same properties indicated in the `propagate` array (and the `propagate` property itself). Default: `[]`
@@ -168,7 +168,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
       'script-props': '',
       'script-export': '',
       attributes: {},
-      traits: ['id', 'title'],
+      traits: [],
       propagate: '',
       dmode: '',
       toolbar: null,

--- a/packages/core/src/dom_components/model/ComponentFrame.ts
+++ b/packages/core/src/dom_components/model/ComponentFrame.ts
@@ -12,7 +12,7 @@ export default class ComponentFrame extends Component {
       tagName: type,
       droppable: false,
       resizable: true,
-      traits: ['id', 'title', 'src'],
+      traits: ['title', 'src'],
       attributes: { frameborder: '0' },
     };
   }

--- a/packages/core/src/dom_components/model/ComponentLabel.ts
+++ b/packages/core/src/dom_components/model/ComponentLabel.ts
@@ -10,7 +10,7 @@ export default class ComponentLabel extends ComponentText {
       ...super.defaults,
       type,
       tagName: type,
-      traits: ['id', 'title', 'for'],
+      traits: ['title', 'for'],
     };
   }
 

--- a/packages/core/src/dom_components/model/types.ts
+++ b/packages/core/src/dom_components/model/types.ts
@@ -212,7 +212,7 @@ export interface ComponentProperties {
   // */
   //script-export?: string | ((...params: any[]) => any);
   /**
-   * Component's traits. More about it [here](/modules/Traits.html). Default: `['id', 'title']`
+   * Component's traits. More about it [here](/modules/Traits.html). Default: `[]`
    * @default ''
    */
   traits?: Traits;


### PR DESCRIPTION
This PR removes `id` and in the general case `title` from the list of default traits to apply to components.